### PR TITLE
Make config.cli optional with default to `npm` like described in README

### DIFF
--- a/src/core/cli.rs
+++ b/src/core/cli.rs
@@ -123,7 +123,7 @@ impl Cli {
     pub fn wp_build(config: Arc<RswConfig>, rsw_type: &str, is_link: bool) {
         let crates_map = Rc::new(RefCell::new(HashMap::new()));
 
-        let cli = &config.cli.to_owned().unwrap();
+        let cli = &config.cli.to_owned().unwrap_or_else(|| "npm".to_string());
         let mut has_crates = false;
         let mut is_exit = true;
 


### PR DESCRIPTION
README mentioned that `config.cli` is an optional with default value of `npm`, while in code it is panicking is `cli` is not set. This PR makes it optional

And thanks for the great tool