### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 .DS_Store
 
 target/
-Cargo.lock
 
 node_modules/
 yarn.lock


### PR DESCRIPTION
Remove cargo lock file from .gitignore for declarative rebuilds

This missing lock file makes rebuilds do new dependency resolution, leading to "it works on my machine" errors. This also makes it harder to package for nix, which is why i noticed this. Lock files should be committed to vsc.

Thanks a lot.