### PR TITLE
feat: allow feature configuration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsw"
-version = "0.8.0"
+version = "0.9.0"
 description = "wasm-pack based build tool"
 edition = "2021"
 authors = ["lencx <cxin1314@gmail.com>"]

--- a/src/config.rs
+++ b/src/config.rs
@@ -71,6 +71,9 @@ pub struct WatchOptions {
     /// which helps when investigating performance issues in a profiler.
     #[serde(default = "default_dev")]
     pub profile: Option<String>,
+    /// Cargo features to activate for this crate in "watch" mode.
+    #[serde(default)]
+    pub features: Option<Vec<String>>,
 }
 
 /// `rsw build` - build config
@@ -89,6 +92,9 @@ pub struct BuildOptions {
     /// which helps when investigating performance issues in a profiler.
     #[serde(default = "default_release")]
     pub profile: Option<String>,
+    /// Cargo features to activate for this crate in "build" mode.
+    #[serde(default)]
+    pub features: Option<Vec<String>>,
 }
 
 /// `rsw new` - new config
@@ -203,6 +209,7 @@ fn default_watch() -> Option<WatchOptions> {
     Some(WatchOptions {
         run: default_true(),
         profile: default_dev(),
+        features: Some(vec![]),
     })
 }
 
@@ -210,5 +217,6 @@ fn default_build() -> Option<BuildOptions> {
     Some(BuildOptions {
         run: default_true(),
         profile: default_release(),
+        features: Some(vec![]),
     })
 }

--- a/src/core/build.rs
+++ b/src/core/build.rs
@@ -48,11 +48,17 @@ impl Build {
 
         // profile
         let mut profile = config.build.as_ref().unwrap().profile.as_ref().unwrap();
+        let mut features = config.build.as_ref().unwrap().features.as_ref().unwrap();
         if rsw_type == "watch" {
             profile = config.watch.as_ref().unwrap().profile.as_ref().unwrap();
+            features = config.watch.as_ref().unwrap().features.as_ref().unwrap();
         }
         let arg_profile = format!("--{}", profile);
+        let arg_features = format!("--features={}", features.join(","));
         args.push(&arg_profile);
+        if !features.is_empty() {
+            args.push(&arg_features);
+        }
 
         // scope
         let (_, scope2) = get_pkg(&self.config.name);


### PR DESCRIPTION
Currently rsw allows configuring the profile used when in `watch` and `build`.

This PR allows also adjusting the features.

Useful when I have some dependencies I only want in development which are feature gated.